### PR TITLE
hold folding state

### DIFF
--- a/autoload/hl_matchit.vim
+++ b/autoload/hl_matchit.vim
@@ -34,6 +34,10 @@ function! hl_matchit#do_highlight()
         endif
     endif
 
+    if foldclosed(line('.')) != -1
+        return
+    endif
+
     let wsv = winsaveview()
     let lcs = []
     while 1


### PR DESCRIPTION
foldmethod が有効な環境で、カーソル移動の度に fold されている箇所がオープンされます。
normal "%" が悪さをしているようなので、fold している箇所では return するよう修正しました。
問題なければ merge お願いします。
